### PR TITLE
Fix serialization empty ArrayField

### DIFF
--- a/searchableselect/widgets.py
+++ b/searchableselect/widgets.py
@@ -49,7 +49,11 @@ class SearchableSelect(forms.CheckboxSelectMultiple):
                 # as strings with comma separated values
                 value = value.split(',')
             else:
-                value = [value]
+                if value == '':
+                    # Empty ArrayField are serialized as ''
+                    value = []
+                else:
+                    value = [value]
 
         queryset = get_model(self.model).objects.filter(**{'{}__in'.format(self.lookup_field): value})
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name='django-searchable-select',
-    version='2.0b2',
+    version='2.0b3',
     description='django-searchable-select - a better and faster multiple selection widget with suggestions for Django',
     long_description="""django-searchable-select
 ========================


### PR DESCRIPTION
Fix error when `ArrayField` is empty in the database, the field value is serialized as empty string `''`, generating an empty tag in the Admin.